### PR TITLE
Improved CTA for GEMconf button on home page

### DIFF
--- a/app/templates/show.hbs
+++ b/app/templates/show.hbs
@@ -4,16 +4,16 @@
 
   {{#gem-cards classNames="two-cards"}}
     {{#gem-card
-      title="GEMconf in the Triangle (Aug 12-16th)"  
+      title="GEMconf Triangle (Aug 12-16th)"  
     }}
     <p>
-      Join us in the Research Triangle for community focused discussions, 
-      talks, and training.
+      Join us in North Carolina for community focused discussions & talks, 
+      a free prototyping workshop with Brendan O'Hara, and classroom training with Emberweekend.
     </p>
-    {{link-to 'Registration' 'gemconf' classNames="button sky-button"}}
+    {{link-to 'More Info' 'gemconf' classNames="button red-button"}}
     {{/gem-card}}
     {{#gem-card
-      title="EmberWeekend Training at GEMconf Triangle (Aug 15-16th)"  
+      title="EmberWeekend Training at GEMconf North Carolina (Aug 15-16th)"  
     }}
       <p>
         Gain solid understanding of all Ember.js fundamentals and build a 


### PR DESCRIPTION
changed button copy to read "More Info" instead of Registration.
Colour = Red
Edited copy to say North Carolina instead of Research Triangle (which I think is not clear or commonly understood enough about the location).
Added names of training instructors.