### PR TITLE
Fix rock and roll hero styles

### DIFF
--- a/app/styles/pages/_rock-and-roll-ember.scss
+++ b/app/styles/pages/_rock-and-roll-ember.scss
@@ -1,36 +1,31 @@
-header.rock-and-roll-ember {
-  background: url(images/RARE-Background.svg) #0A1D25 no-repeat center;
-  height: 658px;
-
-  text-align: center;
+.nav-header.rock-and-roll-ember.with-hero {
+  background: url(images/RARE-Background.svg) center / cover no-repeat #0A1D25;
+  padding-bottom: 40px;
 
   .hero-image {
-    padding-top: 60px;
+    @include margin(40px auto -30px auto);
+    max-width: 400px;
+
     img {
-      @include media($mobile) {
         max-width: 100%;
-      }
-      @include media($tablet) {
-        height: 543px;
-      }
     }
   }
 
   .hero-sub-title {
-    display: inline-block;
-    max-width: 600px;
-    
+    @include margin(null auto);
+    display: block;
+    color: #fff;
     font-family: 'Dosis';
-    color: white;
     font-weight: 100;
+    max-width: 600px;
+    text-align: center;
 
-    @include media($mobile) { 
-      margin-top: -30px; 
+    @include media($mobile) {
       padding-left: 20px;
       padding-right: 20px;
     }
+
     @include media($tablet) {
-      margin-top: -60px;      
       font-size: 36px;
     }
   }
@@ -118,7 +113,7 @@ section.rock-and-roll-ember {
   .max-width-800px {
     max-width: 800px;
   }
-  
+
   .float-right {
     float: right;
   }
@@ -139,7 +134,7 @@ section.rock-and-roll-ember {
 
   .rare-lightning-background {
     background: url(images/RARE-lightning-background.svg) center no-repeat $skyBlue;
-    
+
     .box-content--content {
       padding: 30px 0;
       text-align: center;
@@ -368,7 +363,7 @@ section.rock-and-roll-ember {
       cursor: pointer;
       border: none;
     }
-    
+
     .right {
       padding-left: 10px;
     }


### PR DESCRIPTION
This fix attempts to address the issues on #26.

The logo was cutoff and different viewport sizes and was not centered.

To fix, explicit heights were removed as well as auto values for margin properties were applied. The logo became too big at larger viewports; as such, a max-width is applied to its container to ensure  the image and its subsequent hero do not become too wide as well as tall.

Also noticed the `background-size` property was missing, which was causing the background image to cutoff off at larger viewports.

Since the project utilizes Bourbon, I used their `margin` mixins.